### PR TITLE
Added ability to omit license

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "me.lessis"
 
 name := "bintray-sbt"
 
-version := "0.1.2"
+version := "0.1.2-patch"
 
 description := "package publisher for bintray.com"
 

--- a/src/main/scala/Keys.scala
+++ b/src/main/scala/Keys.scala
@@ -33,9 +33,12 @@ object Keys {
   val whoami = TaskKey[String](
     "whoami", "Print the name of the currently authenticated bintray user")
 
+  val omitLicense = SettingKey[Option[Boolean]](
+     "omitLicense", "Omit license, useful if publishing to a private repo. Defaults to false")
+
   val ensureLicenses = TaskKey[Unit](
     "bintrayEnsureLicenses", "Ensure that the licenses for bintray are valid.")
- 
+
    val ensureCredentials = TaskKey[BintrayCredentials](
     "bintrayEnsureCredentials", "Ensure that the credentials for bintray are valid.")
 
@@ -53,7 +56,7 @@ object Keys {
 
   val syncMavenCentral = TaskKey[Unit](
     "syncMavenCentral", "Sync bintray-published artifacts with maven central")
-    
+
   /** named used for common package attributes lifted from sbt
    *  build definitions */
   object AttrNames {

--- a/src/main/scala/Plugin.scala
+++ b/src/main/scala/Plugin.scala
@@ -280,11 +280,12 @@ object Plugin extends sbt.Plugin with DispatchHandlers {
   /** publishing to bintray requires you must have defined a license they support */
   private def ensureLicensesTask: Initialize[Task[Unit]] =
     task {
+      val omit = omitLicense.value.getOrElse(false)
       val ls = licenses.value
       val acceptable = Licenses.Names.mkString(", ")
-      if (ls.isEmpty) sys.error(
+      if (!omit && ls.isEmpty) sys.error(
         s"you must define at least one license for this project. Please choose one or more of $acceptable")
-      if (!ls.forall { case (name, _) => Licenses.Names.contains(name) }) sys.error(
+      if (!omit && !ls.forall { case (name, _) => Licenses.Names.contains(name) }) sys.error(
         s"One or more of the defined licenses where not among the following allowed licenses $acceptable")
     }
 
@@ -372,6 +373,7 @@ object Plugin extends sbt.Plugin with DispatchHandlers {
         val sv = Map(AttrNames.scalas -> scalaVersions.map(VersionAttr(_)))
         if (plugin) sv ++ Map(AttrNames.sbtVersion-> Seq(VersionAttr(sbtVersion))) else sv
     },
+    omitLicense in bintray in Global := { if (sbtPlugin.value) Some(sbtPlugin.value) else None },
     ensureLicenses <<= ensureLicensesTask,
     ensureCredentials <<= ensureCredentialsTask,
     ensureBintrayPackageExists <<= ensurePackageTask,


### PR DESCRIPTION
Added the ability to omit/skip specifying a license. Useful when publishing to a private (premium) repo.